### PR TITLE
Add basic docker-compose and Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,24 @@
 > Website for aggregating cEDH tournament data
 
 ## How to Contribute
-After cloning this repository, contact Jason for instructions on building the database. Becasue we rely on external APIs, our database update scripts don't work as-is. We're working on a script to pull form the EDHTop16 main database.
+After cloning this repository, contact Jason for instructions on building the database. Becasue we rely on external APIs, our database update scripts don't work as-is. We're working on a script to pull from the EDHTop16 main database.
 
-### Start Backend
+## Running using Docker
+[Docker](https://www.docker.com/) is a simpler way of running and managing the application stack. To get this working:
+- Install [Docker Desktop](https://www.docker.com/products/docker-desktop/) on your system.
+- Run `docker-compose up` to stand up the backend and mongodb instance.
+- Run the frontend using the instructions below.
+
+Alternatively, if you wish to simply run the database, run `docker-compose up -d mongodb`.
+
+Automatic seeding of the database has not yet been implemented - to seed the database from a zip file, you can do the following:
+- Unzip the seed folder
+- Run `docker cp path_to_seed_folder/ mongodb:/root/mongo_seed`
+- Run `docker-compose exec -T mongodb mongorestore -d cedhtop16 /root/mongo_seed/cedhtop16`
+
+
+## Running without Docker
+### Start Backend 
 [`server/`](/server/)
 ```
 cd ./server/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  python-app:
+    build: 
+      context: server
+      dockerfile: Dockerfile
+    environment:
+      - MONGO_URI=mongodb://mongodb:27017
+      - PORT=8000
+    ports:
+      - '8000:8000'
+    depends_on:
+      - mongodb
+    networks:
+      - py-network
+
+  mongodb:
+    image: mongo:6-jammy
+    ports:
+      - '27017:27017'
+    volumes:
+      - dbdata:/data/db
+    networks:
+      - py-network
+
+volumes:
+  dbdata:
+
+networks:
+  py-network:
+    driver: bridge

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,7 @@
+FROM tiangolo/uvicorn-gunicorn-fastapi:python3.11
+
+COPY ./requirements.txt /app/requirements.txt
+
+RUN pip install --no-cache-dir --upgrade -r /app/requirements.txt
+
+COPY ./ /app


### PR DESCRIPTION
## Context
This PR adds a basic Dockerfile and docker-compose setup - `mongodb` doesn't always play nicely on everyone's system and this makes it a little nicer to work in. 