### PR TITLE
Fix Python server type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pyright]
+include = ["server"]
+exclude = ["server_old"]

--- a/server/db/base_db.py
+++ b/server/db/base_db.py
@@ -1,10 +1,9 @@
-from fastapi import FastAPI
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorDatabase
-from typing import Optional
+from typing import Optional, cast
 import os
 
 client: Optional[AsyncIOMotorClient] = None
-MONGO_URI: str = os.getenv("MONGO_URI")
+MONGO_URI = cast(str, os.getenv("MONGO_URI"))
 
 
 async def startup():
@@ -19,4 +18,7 @@ async def shutdown():
 
 
 async def get_db_async(db_name: str) -> AsyncIOMotorDatabase:
+    if client is None:
+        raise RuntimeError("Must initialize database with startup() before accessing!")
+
     return client[db_name]

--- a/server/db/tournaments_db.py
+++ b/server/db/tournaments_db.py
@@ -1,9 +1,9 @@
-from typing import List
+from typing import List, Any
 import logging
 
 from .base_db import get_db_async
 from utils import oIdToString
-from utils.types import AllFilters, TournamentFilters, Tournament, Commander
+from utils.types import AllFilters, TournamentFilters, Tournament, Commander, Entry
 
 
 async def get_tournaments(tournament_filters: TournamentFilters) -> List[Tournament]:
@@ -13,8 +13,9 @@ async def get_tournaments(tournament_filters: TournamentFilters) -> List[Tournam
     db = await get_db_async("cedhtop16")
     metadata = db["metadata"]
 
-    result = await metadata.find(tournament_filters, {"_id": 0}).to_list(length=None)
-    return result
+    db_filters = tournament_filters.model_dump(by_alias=True, exclude_unset=True, exclude_none=True)
+    result: List[Any] = await metadata.find(db_filters, {"_id": 0}).to_list(length=10000) # type: ignore
+    return [Tournament(**t) for t in result]
 
 
 async def get_commanders(filters: AllFilters) -> dict[str, Commander]:
@@ -26,7 +27,7 @@ async def get_commanders(filters: AllFilters) -> dict[str, Commander]:
     commanders: dict[str, Commander] = {}
     for player in players:
         # For each player, check if the commander is in the dictionary.
-        commander = player.get("commander", "")
+        commander = player.commander or ""
         if not commander:
             logging.warning(f"Can't get commander for player: {player}")
             continue
@@ -37,86 +38,88 @@ async def get_commanders(filters: AllFilters) -> dict[str, Commander]:
 
         if commander not in commanders:
             # If the commander is not in the dictionary, add it.
-            commanders[commander] = {
-                "colorID": player.get("colorID", "") or "",
-                "wins": player.get("wins", 0) or 0,
-                "winsSwiss": player.get("winsSwiss", 0) or 0,
-                "winsBracket": player.get("winsBracket", 0) or 0,
-                "draws": player.get("draws", 0) or 0,
-                "losses": player.get("losses", 0) or 0,
-                "lossesSwiss": player.get("lossesSwiss", 0) or 0,
-                "lossesBracket": player.get("lossesBracket", 0) or 0,
-                "topCuts": 1 if player.get("standing", float('inf')) <= player.get("topCut", 0) else 0,
-                "count": 1
-            }
+            commanders[commander] = Commander(
+                colorID= player.colorID or "",
+                wins= player.wins or 0,
+                winsSwiss= player.winsSwiss or 0,
+                winsBracket= player.winsBracket or 0,
+                draws= player.draws or 0,
+                losses= player.losses or 0,
+                lossesSwiss= player.lossesSwiss or 0,
+                lossesBracket= player.lossesBracket or 0,
+                topCuts= 1 if (player.standing or float('inf')) <= (player.topCut or 0) else 0,
+                count= 1
+            )
         else:
             # If the commander is in the dictionary, update it.
-            c = commanders.get(commander, {})
-            if c == {}:
+            c = commanders.get(commander)
+            if c is None:
                 logging.warning(f"Malformed commander: {commander}")
                 continue
 
             # If the colorID is not set, set it if this player has a valid colorID.
-            if player.get("colorID", "") in {"", "N/A"} and not c["colorID"]:
-                c["colorID"] = player["colorID"]
+            if player.colorID in {"", "N/A"} and not c.colorID:
+                c.colorID = player.colorID
 
             # Update counting stat fields
-            fields = ["wins", "winsSwiss", "winsBracket",
-                      "draws", "losses", "lossesSwiss", "lossesBracket"]
-            for field in fields:
-                c[field] += player.get(field, 0) or 0
+            c.wins = (c.wins or 0)  + (player.wins or 0)
+            c.winsSwiss = (c.winsSwiss or 0)  + (player.winsSwiss or 0)
+            c.winsBracket = (c.winsBracket or 0)  + (player.winsBracket or 0)
+            c.draws = (c.draws or 0)  + (player.draws or 0)
+            c.losses = (c.losses or 0)  + (player.losses or 0)
+            c.lossesSwiss = (c.lossesSwiss or 0)  + (player.lossesSwiss or 0)
+            c.lossesBracket = (c.lossesBracket or 0)  + (player.lossesBracket or 0)
 
-            if player.get("standing", float('inf')) <= player.get("topCut", 0):
-                c["topCuts"] += 1
+            if (player.standing or float('inf')) <= (player.topCut or 0):
+                c.topCuts = (c.topCuts or 0) + 1
             # Increment counter
-            c["count"] += 1
+            c.count = (c.count or 0)+ 1
 
     # Calculate the winRate, winRateSwiss, and winRateBracket
     for commander in commanders:
         c = commanders[commander]
-        c["winRate"] = c["wins"] / (c["wins"] + c["losses"] + c["draws"]) \
-            if (c["wins"] + c["losses"] + c["draws"]) > 0 else None
-        c["winRateSwiss"] = c["winsSwiss"] / \
-            (c["winsSwiss"] + c["lossesSwiss"] + c["draws"]) \
-            if (c["winsSwiss"] + c["lossesSwiss"] + c["draws"]) > 0 else None
-        c["winRateBracket"] = c["winsBracket"] / (c["wins"] + c["losses"]) \
-            if (c["wins"] + c["losses"]) > 0 else None
-        c["conversionRate"] = c["topCuts"] / c["count"]
+        c.winRate = (c.wins or 0) / ((c.wins or 0) + (c.losses or 0) + (c.draws or 0)) \
+            if ((c.wins or 0) + (c.losses or 0) + (c.draws or 0)) > 0 else None
+        c.winRateSwiss = (c.winsSwiss or 0) / \
+            ((c.winsSwiss or 0) + (c.lossesSwiss or 0) + (c.draws or 0)) \
+            if ((c.winsSwiss or 0) + (c.lossesSwiss or 0) + (c.draws or 0)) > 0 else None
+        c.winRateBracket = (c.winsBracket or 0) / ((c.wins or 0) + (c.losses or 0)) \
+            if ((c.wins or 0) + (c.losses or 0)) > 0 else None
+        c.conversionRate = (c.topCuts or 0) / (c.count or 0)
 
     return commanders
 
 
-async def get_entries(filters: AllFilters) -> List[dict]:
+async def get_entries(filters: AllFilters) -> List[Entry]:
     """
     Returns a list of players from the database.
     """
     db = await get_db_async("cedhtop16")
 
-    tournament_filters = filters.get("tournament_filters", {})
+    tournament_filters = filters.tournament_filters or TournamentFilters()
     tournaments = await get_tournaments(tournament_filters)
-    if "tournament_filters" in filters:
-        del filters["tournament_filters"]
+    if filters.tournament_filters is not None:
+        filters.tournament_filters = None
 
-    res: List[dict] = []
+    res: List[Entry] = []
     for tournament in tournaments:
         # Get the TID from the metadata document
-        tid = tournament["TID"]
-        if tid == "":
+        tid = tournament.TID
+        if tid is None or tid == "":
             logging.warning(f"Empty TID for tournament: {tournament}")
             continue
 
         # Get the tournament with matching TID from the database
         t = db[tid]
-        if t is None:
-            logging.warning(f"Could not find tournament: {tid}")
-            continue
 
         # Get the tournament data from the database
-        result = await t.find(filters).to_list(length=None)
+        db_filters = filters.model_dump(by_alias=True, exclude_unset=True, exclude_none=True)
+        result: List[Any] = await t.find(db_filters).to_list(length=10000) # type: ignore
         for i in result:
             i['TID'] = tid
-            i['tournamentName'] = tournament.get('tournamentName', "")
-            i['topCut'] = tournament.get('topCut', 0)   
-        res.extend(result)
+            i['tournamentName'] = tournament.tournamentName
+            i['topCut'] = tournament.topCut or 0   
+
+        res.extend([Entry(**e) for e in result])
 
     return oIdToString(res)

--- a/server/routers/commanders.py
+++ b/server/routers/commanders.py
@@ -8,4 +8,4 @@ router = APIRouter()
 
 @router.post("/commanders")
 async def get_commanders(filters: AllFilters = Body(...)) -> dict[str, Commander]:
-    return await get_commanders_db(filters.model_dump(by_alias=True, exclude_unset=True, exclude_none=True))
+    return await get_commanders_db(filters)

--- a/server/routers/entries.py
+++ b/server/routers/entries.py
@@ -14,5 +14,5 @@ async def get_entries(filters: AllFilters = Body(...)) -> List[Entry]:
     Returns a list of entries from the database given a filter.
     """
     # Using by_alias to convert the filters to the database format.
-    data = await get_entries_db(filters.model_dump(by_alias=True, exclude_unset=True, exclude_none=True))
+    data = await get_entries_db(filters)
     return data

--- a/server/routers/players.py
+++ b/server/routers/players.py
@@ -1,5 +1,4 @@
-from fastapi import APIRouter, Body, HTTPException
-from typing import List
+from fastapi import APIRouter, HTTPException
 
 from db import get_entries as get_entries_db
 from utils.types import Player, AllFilters
@@ -14,28 +13,35 @@ async def player(profile: str) -> Player:
     Returns a list of entries from the database given a filter.
     """
     # Using by_alias to convert the filters to the database format.
-    data = await get_entries_db({"profile": profile})
+    data = await get_entries_db(AllFilters(profile=profile))
     if not data:
         raise HTTPException(status_code=404, detail=f"No player with profile '{profile}'")
-    fields = ["wins", "winsSwiss", "winsBracket", "draws", "losses", "lossesSwiss", "lossesBracket"]
-    out: Player = {field: 0 for field in fields}
-    out['tournaments'] = []
-    out['name'] = data[0].get('name', "")
-    out['profile'] = profile
+    
+    out  = Player(wins=0, winsSwiss=0, winsBracket=0, draws=0, losses=0, lossesSwiss=0, lossesBracket=0)
+    out.tournaments = []
+    out.name = data[0].name or ""
+    out.profile = profile
 
     topCuts = 0
     
     for entry in data:
-        for field in fields:
-            out[field] += entry.get(field, 0)
-        if entry.get('standing', float('inf')) <= entry.get('topCut', 0):
+        out.wins = (out.wins or 0) + (entry.wins or 0)
+        out.winsSwiss = (out.winsSwiss or 0) + (entry.winsSwiss or 0)
+        out.winsBracket = (out.winsBracket or 0) + (entry.winsBracket or 0)
+        out.draws = (out.draws or 0) + (entry.draws or 0)
+        out.losses = (out.losses or 0) + (entry.losses or 0)
+        out.lossesSwiss = (out.lossesSwiss or 0) + (entry.lossesSwiss or 0)
+        out.lossesBracket = (out.lossesBracket or 0) + (entry.lossesBracket or 0)
+
+        if (entry.standing or float('inf')) <= (entry.topCut or 0):
             topCuts += 1
-        out['tournaments'].append(entry)
+
+        out.tournaments.append(entry)
     
-    out["winRate"] = out["wins"] / (out["wins"] + out["draws"] + out["losses"])
-    out["winRateSwiss"] = out["winsSwiss"] / (out["winsSwiss"] + out["draws"] + out["lossesSwiss"])
-    out["winRateBracket"] = out["winsBracket"] / (out["winsBracket"] + out["lossesBracket"])
-    out["conversionRate"] = topCuts / len(out["tournaments"])
-    out["topCuts"] = topCuts
+    out.winRate = (out.wins or 0) / ((out.wins or 0) + (out.draws or 0) + (out.losses or 0))
+    out.winRateSwiss = (out.winsSwiss or 0) / ((out.winsSwiss or 0) + (out.draws or 0) + (out.lossesSwiss or 0))
+    out.winRateBracket = (out.winsBracket or 0) / ((out.winsBracket or 0) + (out.lossesBracket or 0))
+    out.conversionRate = topCuts / len(out.tournaments)
+    out.topCuts = topCuts
 
     return out

--- a/server/routers/tournaments.py
+++ b/server/routers/tournaments.py
@@ -14,5 +14,5 @@ async def get_tournaments(filters: TournamentFilters = Body(...)) -> List[Tourna
     Returns a list of tournaments from the database given a filter.
     """
     # Using by_alias to convert the filters to the database format.
-    data = await get_tournaments_db(filters.model_dump(by_alias=True, exclude_unset=True, exclude_none=True))
+    data = await get_tournaments_db(filters)
     return data

--- a/server/utils/oIdToString.py
+++ b/server/utils/oIdToString.py
@@ -1,10 +1,11 @@
-from typing import List
+from typing import List, Any
 
 
-def oIdToString(list: List):
+def oIdToString(list: List[Any]):
     """
     Converts the _id field of a list of dictionaries from ObjectId to string.
     """
     for i in range(len(list)):
         list[i]["_id"] = str(list[i]["_id"])
+
     return list

--- a/server/utils/types/filters.py
+++ b/server/utils/types/filters.py
@@ -1,9 +1,9 @@
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field
 from typing import TypeVar, Generic, Optional, List, Dict, Union
-from datetime import date
+import datetime
 
 
-T = TypeVar("T", int, date)
+T = TypeVar("T", int, datetime.date)
 
 
 class OperatorType(BaseModel, Generic[T]):
@@ -50,7 +50,7 @@ class BaseFilters(BaseModel):
 
 
 class TournamentFilters(BaseModel):
-    date: Optional[OperatorType[date]] = None
+    date: Optional[OperatorType[datetime.date]] = None
     dateCreated: Optional[OperatorType[int]] = None
     size: Optional[OperatorType[int]] = None
     TID: Optional[str] = None
@@ -65,5 +65,3 @@ class TournamentFilters(BaseModel):
 class AllFilters(BaseFilters):
     tournament_filters: Optional[TournamentFilters] = None
 
-    class Config:
-        extra = "forbid"


### PR DESCRIPTION
The new Python server makes heavy use of Pyright and type annotations but when running a type checker there are many type errors. These are mainly due to using Pydantic types as dictionaries. I have fixed all the type errors found using Pyright and updated the runtime code to work with the actual Pydantic types that are specified in the type annotations, rather than dictionaries that resemble the types. I would appreciate help verifying the runtime behavior of the server with this change.