### PR TITLE
Move next-gen API to `/api/v2`

### DIFF
--- a/client/src/api/commander.ts
+++ b/client/src/api/commander.ts
@@ -10,7 +10,7 @@ export async function getCommanders(
   if (!v.success) throw new Error("Invalid filters");
 
   const res = await axios.post<AllFiltersType>(
-    "http://localhost:8000/api/commanders",
+    "http://localhost:8000/api/v2/commanders",
     filters,
     { timeout: 10000 },
   );

--- a/server/main.py
+++ b/server/main.py
@@ -23,7 +23,7 @@ logging.basicConfig(
 """
 All routes
 """
-prefix = "/api"
+prefix = "/api/v2"
 app.include_router(commanders_router, prefix=prefix)
 app.include_router(tournaments_router, prefix=prefix)
 app.include_router(entries_router, prefix=prefix)
@@ -45,7 +45,7 @@ app.add_middleware(
 )
 
 
-app.include_router(graphql_app, prefix="/api/graphql")
+app.include_router(graphql_app, prefix=prefix + "/graphql")
 
 """
 App startup and shutdown scripts


### PR DESCRIPTION
Moving the new API to a new route allows us to route requests to `/api/v2` to the new server, while all other `/api` requests are forward to the legacy server. This allows running both simultaniously, letting the client use both old and new code at the same time.