### PR TITLE
Enable introspection for production GraphQL endpoint

### DIFF
--- a/client/src/pages/api/graphql.ts
+++ b/client/src/pages/api/graphql.ts
@@ -2,7 +2,7 @@ import { ApolloServer } from "@apollo/server";
 import { startServerAndCreateNextHandler } from "@as-integrations/next";
 import { createContext, schema } from "../../lib/server/schema";
 
-const server = new ApolloServer({ schema });
+const server = new ApolloServer({ schema, introspection: true });
 
 export default startServerAndCreateNextHandler(server, {
   context: async () => createContext(),


### PR DESCRIPTION
Allows https://studio.apollographql.com/sandbox/explorer/ to act like API documentation for us