### PR TITLE
Track players only by topdeck.gg profile

### DIFF
--- a/client/prisma/migrations/20240430001123_topdeck_profile_unique/migration.sql
+++ b/client/prisma/migrations/20240430001123_topdeck_profile_unique/migration.sql
@@ -1,0 +1,45 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `size000EntryCount` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size000Top04ConversionRate` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size000Top04Count` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size000Top16ConversionRate` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size000Top16Count` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size064EntryCount` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size064Top04ConversionRate` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size064Top04Count` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size064Top16ConversionRate` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size064Top16Count` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size128EntryCount` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size128Top04ConversionRate` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size128Top04Count` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size128Top16ConversionRate` on the `Commander` table. All the data in the column will be lost.
+  - You are about to drop the column `size128Top16Count` on the `Commander` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Entry" DROP CONSTRAINT "Entry_playerUuid_fkey";
+
+-- AlterTable
+ALTER TABLE "Commander" DROP COLUMN "size000EntryCount",
+DROP COLUMN "size000Top04ConversionRate",
+DROP COLUMN "size000Top04Count",
+DROP COLUMN "size000Top16ConversionRate",
+DROP COLUMN "size000Top16Count",
+DROP COLUMN "size064EntryCount",
+DROP COLUMN "size064Top04ConversionRate",
+DROP COLUMN "size064Top04Count",
+DROP COLUMN "size064Top16ConversionRate",
+DROP COLUMN "size064Top16Count",
+DROP COLUMN "size128EntryCount",
+DROP COLUMN "size128Top04ConversionRate",
+DROP COLUMN "size128Top04Count",
+DROP COLUMN "size128Top16ConversionRate",
+DROP COLUMN "size128Top16Count";
+
+-- AlterTable
+ALTER TABLE "Entry" ALTER COLUMN "playerUuid" DROP NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "Entry" ADD CONSTRAINT "Entry_playerUuid_fkey" FOREIGN KEY ("playerUuid") REFERENCES "Player"("uuid") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/client/prisma/migrations/20240430001220_topdeck_profile_unique_pt2/migration.sql
+++ b/client/prisma/migrations/20240430001220_topdeck_profile_unique_pt2/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[topdeckProfile]` on the table `Player` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "Player_topdeckProfile_key" ON "Player"("topdeckProfile");

--- a/client/prisma/schema.prisma
+++ b/client/prisma/schema.prisma
@@ -34,7 +34,7 @@ model Player {
   uuid String @id @db.Uuid
 
   /// Unique topdeck profile ID.
-  topdeckProfile String?
+  topdeckProfile String? @unique
   /// Name of this player, as found in their most recent tournament.
   name           String
 
@@ -55,9 +55,9 @@ model Commander {
 model Entry {
   uuid String @id @db.Uuid
 
-  tournamentUuid String @db.Uuid
-  playerUuid     String @db.Uuid
-  commanderUuid  String @db.Uuid
+  tournamentUuid String  @db.Uuid
+  playerUuid     String? @db.Uuid
+  commanderUuid  String  @db.Uuid
 
   standing      Int
   decklist      String?
@@ -68,6 +68,6 @@ model Entry {
   lossesBracket Int
 
   tournament Tournament @relation(fields: [tournamentUuid], references: [uuid])
-  player     Player     @relation(fields: [playerUuid], references: [uuid])
+  player     Player?    @relation(fields: [playerUuid], references: [uuid])
   commander  Commander  @relation(fields: [commanderUuid], references: [uuid])
 }

--- a/client/src/lib/server/schema.ts
+++ b/client/src/lib/server/schema.ts
@@ -239,7 +239,7 @@ const EntryType = builder.prismaObject("Entry", {
     lossesSwiss: t.exposeInt("lossesSwiss"),
     lossesBracket: t.exposeInt("lossesBracket"),
     commander: t.relation("commander"),
-    player: t.relation("player"),
+    player: t.relation("player", { nullable: true }),
     tournament: t.relation("tournament"),
     wins: t.int({
       resolve: (parent) => parent.winsBracket + parent.winsSwiss,

--- a/client/src/queries/schema.graphql
+++ b/client/src/queries/schema.graphql
@@ -16,7 +16,7 @@ type Entry {
   losses: Int!
   lossesBracket: Int!
   lossesSwiss: Int!
-  player: Player!
+  player: Player
   standing: Int!
   tournament: Tournament!
   wins: Int!


### PR DESCRIPTION
Previously we were associating players by name, and ignoring topdeck.gg profile. This changes the logic such that we only track players via topdeck.gg profile, rather than name. This results in `player` now being nullable, as not all entries have an associated topdeck profile.